### PR TITLE
Feat/#4 oauth2 인증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/verifit/verifit/auth/contoller/AuthController.java
+++ b/src/main/java/com/verifit/verifit/auth/contoller/AuthController.java
@@ -1,0 +1,22 @@
+package com.verifit.verifit.auth.contoller;
+
+import com.verifit.verifit.auth.domain.response.Oauth2Response;
+import com.verifit.verifit.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/{provider}")
+    public Oauth2Response authenticate(
+            @PathVariable String provider,
+            @RequestParam String code
+    ){
+        return authService.authenticate(provider, code);
+    }
+}

--- a/src/main/java/com/verifit/verifit/auth/domain/response/Oauth2Response.java
+++ b/src/main/java/com/verifit/verifit/auth/domain/response/Oauth2Response.java
@@ -1,0 +1,7 @@
+package com.verifit.verifit.auth.domain.response;
+
+public record Oauth2Response(
+        String redirect,
+        String accessToken
+) {
+}

--- a/src/main/java/com/verifit/verifit/auth/service/AuthService.java
+++ b/src/main/java/com/verifit/verifit/auth/service/AuthService.java
@@ -1,0 +1,41 @@
+package com.verifit.verifit.auth.service;
+
+import com.verifit.verifit.auth.domain.response.Oauth2Response;
+import com.verifit.verifit.client.oauth2.domain.Oauth2UserInfo;
+import com.verifit.verifit.client.oauth2.service.Oauth2Service;
+import com.verifit.verifit.global.jwt.JwtProvider;
+import com.verifit.verifit.member.dao.MemberRepository;
+import com.verifit.verifit.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final Oauth2Service oauth2Service;
+    private final JwtProvider jwtProvider;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Oauth2Response authenticate(String provider, String code) {
+        Oauth2UserInfo userInfo = oauth2Service.getUserResource(provider, code);
+
+        Member member = findOauth2Member(userInfo.getProvider(), userInfo.getProviderId());
+
+        return new Oauth2Response(getRedirect(member), jwtProvider.generateAccessToken(member));
+    }
+
+    private Member findOauth2Member(String provider, String providerId) {
+        return memberRepository
+                .findByProviderAndProviderId(provider, providerId)
+                .orElseGet(() -> memberRepository.save(Member.createOauthMember(provider, providerId)));
+    }
+
+    private String getRedirect(Member member){
+        return StringUtils.hasText(member.getNickname()) ? "/signup" : "/";
+    }
+}

--- a/src/main/java/com/verifit/verifit/client/oauth2/config/Oauth2Adapter.java
+++ b/src/main/java/com/verifit/verifit/client/oauth2/config/Oauth2Adapter.java
@@ -1,0 +1,17 @@
+package com.verifit.verifit.client.oauth2.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Oauth2Adapter {
+
+    private Oauth2Adapter() {}
+
+    public static Map<String, Oauth2Provider> getOauthProviders(Oauth2Properties properties) {
+        Map<String, Oauth2Provider> oauth2Provider = new HashMap<>();
+
+        properties.getClient()
+                .forEach((key, value) -> oauth2Provider.put(key, new Oauth2Provider(value)));
+        return oauth2Provider;
+    }
+}

--- a/src/main/java/com/verifit/verifit/client/oauth2/config/Oauth2Config.java
+++ b/src/main/java/com/verifit/verifit/client/oauth2/config/Oauth2Config.java
@@ -1,0 +1,23 @@
+package com.verifit.verifit.client.oauth2.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(Oauth2Properties.class)
+public class Oauth2Config {
+
+    private final Oauth2Properties properties;
+
+    @Bean
+    public Oauth2ProviderFactory oauth2ProviderFactory() {
+        Map<String, Oauth2Provider> providers = Oauth2Adapter.getOauthProviders(properties);
+        return new Oauth2ProviderFactory(providers);
+    }
+
+}

--- a/src/main/java/com/verifit/verifit/client/oauth2/config/Oauth2Properties.java
+++ b/src/main/java/com/verifit/verifit/client/oauth2/config/Oauth2Properties.java
@@ -1,0 +1,26 @@
+package com.verifit.verifit.client.oauth2.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@ConfigurationProperties(prefix = "oauth2")
+public class Oauth2Properties {
+
+    private final Map<String, Client> client = new HashMap<>();
+
+    @Getter
+    @Setter
+    public static class Client {
+        private String clientId;
+        private String clientSecret;
+        private String redirectUri;
+        private String tokenUri;
+        private String userInfoUri;
+        private String userNameAttribute;
+    }
+}

--- a/src/main/java/com/verifit/verifit/client/oauth2/config/Oauth2Provider.java
+++ b/src/main/java/com/verifit/verifit/client/oauth2/config/Oauth2Provider.java
@@ -1,0 +1,33 @@
+package com.verifit.verifit.client.oauth2.config;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Oauth2Provider {
+
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+    private final String tokenUri;
+    private final String userInfoUri;
+
+    public Oauth2Provider(Oauth2Properties.Client client) {
+        this(
+                client.getClientId(),
+                client.getClientSecret(),
+                client.getRedirectUri(),
+                client.getTokenUri(),
+                client.getUserInfoUri()
+        );
+    }
+
+    @Builder
+    public Oauth2Provider(String clientId, String clientSecret, String redirectUri, String tokenUri, String userInfoUri) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+        this.tokenUri = tokenUri;
+        this.userInfoUri = userInfoUri;
+    }
+}

--- a/src/main/java/com/verifit/verifit/client/oauth2/config/Oauth2ProviderFactory.java
+++ b/src/main/java/com/verifit/verifit/client/oauth2/config/Oauth2ProviderFactory.java
@@ -1,0 +1,24 @@
+package com.verifit.verifit.client.oauth2.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Oauth2ProviderFactory {
+
+    private final Map<String, Oauth2Provider> providers;
+
+    public Oauth2ProviderFactory(Map<String, Oauth2Provider> providers) {
+        this.providers = new HashMap<>(providers);
+    }
+
+    public Oauth2Provider getByProviderName(String name) {
+        if(!isValidOauth2Provider(name)){
+            throw new RuntimeException();
+        }
+        return providers.get(name);
+    }
+
+    private boolean isValidOauth2Provider(String name){
+        return providers.containsKey(name);
+    }
+}

--- a/src/main/java/com/verifit/verifit/client/oauth2/domain/Oauth2TokenDto.java
+++ b/src/main/java/com/verifit/verifit/client/oauth2/domain/Oauth2TokenDto.java
@@ -1,0 +1,12 @@
+package com.verifit.verifit.client.oauth2.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record Oauth2TokenDto(
+        @JsonProperty("token_type")
+        String tokenType,
+        @JsonProperty("access_token")
+        String accessToken,
+        String scope
+) {
+}

--- a/src/main/java/com/verifit/verifit/client/oauth2/domain/Oauth2UserInfo.java
+++ b/src/main/java/com/verifit/verifit/client/oauth2/domain/Oauth2UserInfo.java
@@ -1,0 +1,43 @@
+package com.verifit.verifit.client.oauth2.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Map;
+
+
+@RequiredArgsConstructor
+@Getter
+public enum Oauth2UserInfo {
+
+    KAKAO("kakao") {
+        @Override
+        public String getProviderId() {
+            return String.valueOf(this.getUserAttributes().get("id"));
+        }
+    },
+    GOOGLE("google"){
+        @Override
+        public String getProviderId() {
+            return String.valueOf(this.getUserAttributes().get("sub"));
+        }
+    }
+
+    ;
+
+    private final String provider;
+    private Map<String, Object> userAttributes;
+
+    public abstract String getProviderId();
+
+    public static Oauth2UserInfo createOauth2UserInfo(String provider, Map<String, Object> userAttributes){
+        Oauth2UserInfo oauth2UserInfo = Arrays.stream(Oauth2UserInfo.values())
+                .filter(userInfo -> userInfo.provider.equals(provider))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("not supported oauth2 provider"));
+        oauth2UserInfo.userAttributes = userAttributes;
+        return oauth2UserInfo;
+    }
+
+}

--- a/src/main/java/com/verifit/verifit/client/oauth2/service/Oauth2Service.java
+++ b/src/main/java/com/verifit/verifit/client/oauth2/service/Oauth2Service.java
@@ -1,0 +1,74 @@
+package com.verifit.verifit.client.oauth2.service;
+
+import com.verifit.verifit.client.oauth2.config.Oauth2Provider;
+import com.verifit.verifit.client.oauth2.config.Oauth2ProviderFactory;
+import com.verifit.verifit.client.oauth2.domain.Oauth2TokenDto;
+import com.verifit.verifit.client.oauth2.domain.Oauth2UserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class Oauth2Service {
+
+    private final Oauth2ProviderFactory factory;
+    private final String OAUTH2_GRANT_TYPE = "authorization_code";
+
+    public Oauth2UserInfo getUserResource(String providerName, String code) {
+        Oauth2Provider provider = factory.getByProviderName(providerName);
+
+        Oauth2TokenDto tokenDto = getToken(provider, code);
+
+        return getUserProfile(providerName, provider, tokenDto);
+    }
+
+    private Oauth2UserInfo getUserProfile(String provider, Oauth2Provider oauth2Provider, Oauth2TokenDto tokenDto) {
+        Map<String, Object> userAttributes = getUserAttributes(oauth2Provider, tokenDto);
+        return Oauth2UserInfo.createOauth2UserInfo(provider, userAttributes);
+    }
+
+    private Map<String, Object> getUserAttributes(Oauth2Provider provider, Oauth2TokenDto tokenDto) {
+        return WebClient.create()
+                .get()
+                .uri(provider.getUserInfoUri())
+                .headers(header -> header.setBearerAuth(tokenDto.accessToken()))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+    }
+
+    private Oauth2TokenDto getToken(Oauth2Provider provider, String code) {
+        return WebClient.create()
+                .post()
+                .uri(provider.getTokenUri())
+                .headers(header -> {
+                    header.setBasicAuth(provider.getClientId(), provider.getClientSecret());
+                    header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                    header.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+                    header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+                })
+                .bodyValue(createTokenRequest(code, provider))
+                .retrieve()
+                .bodyToMono(Oauth2TokenDto.class)
+                .block();
+    }
+
+    private MultiValueMap<String, String> createTokenRequest(String code, Oauth2Provider provider) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("code", code);
+        formData.add("client_id", provider.getClientId());
+        formData.add("client_secret", provider.getClientSecret());
+        formData.add("grant_type", OAUTH2_GRANT_TYPE);
+        formData.add("redirect_uri", provider.getRedirectUri());
+        return formData;
+    }
+}

--- a/src/main/java/com/verifit/verifit/member/dao/MemberRepository.java
+++ b/src/main/java/com/verifit/verifit/member/dao/MemberRepository.java
@@ -10,6 +10,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
+    Optional<Member> findByProviderAndProviderId(String provider, String providerId);
+
     boolean existsByNickname(String nickname);
 
     boolean existsByEmail(String email);

--- a/src/main/java/com/verifit/verifit/member/entity/Member.java
+++ b/src/main/java/com/verifit/verifit/member/entity/Member.java
@@ -43,6 +43,21 @@ public class Member {
     @NotBlank(message = "프로필 URL은 필수입니다.")
     private String profileUrl;
 
+    @Column
+    @NotBlank(message = "provider는 필수입니다.")
+    private String provider;
+
+    @Column
+    @NotBlank(message = "provider id는 필수입니다.")
+    private String providerId;
+
+    public static Member createOauthMember(String provider, String providerId){
+        return Member.builder()
+                .provider(provider)
+                .providerId(providerId)
+                .build();
+    }
+
     public void changePassword(String newPassword) {
         password = newPassword;
     }


### PR DESCRIPTION
http 요청을 위해서 webflux 안에 있는 web client 사용했어요.
레포지토리가 public이라 application.yml에 들어가는 oauth2 인증 정보는 일단 뺐습니다.

인증 순서가 디스코드에 올린 내용에 더불어
처음 가입하는 유저인 경우 회원가입을 유도해야하는데
일단 빈 member에 oauth2 정보를 저장하도록 하였어요.

이런 방식을 주로 사용했었는데 빈 member를 만드는 과정에서 entity validator랑 잘 맞지 않아서..
한번 얘기해보면 좋을 것 같습니다 !