### PR TITLE
Feat/#13 예외 양식 통일, 전역 예외처리

### DIFF
--- a/src/main/java/com/verifit/verifit/client/oauth2/config/Oauth2ProviderFactory.java
+++ b/src/main/java/com/verifit/verifit/client/oauth2/config/Oauth2ProviderFactory.java
@@ -1,5 +1,8 @@
 package com.verifit.verifit.client.oauth2.config;
 
+import com.verifit.verifit.global.exception.ApiException;
+import com.verifit.verifit.global.exception.ExceptionCode;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -13,7 +16,7 @@ public class Oauth2ProviderFactory {
 
     public Oauth2Provider getByProviderName(String name) {
         if(!isValidOauth2Provider(name)){
-            throw new RuntimeException();
+            throw new ApiException(ExceptionCode.OAUTH2_PROVIDER_NOT_SUPPORTED);
         }
         return providers.get(name);
     }

--- a/src/main/java/com/verifit/verifit/client/oauth2/domain/Oauth2UserInfo.java
+++ b/src/main/java/com/verifit/verifit/client/oauth2/domain/Oauth2UserInfo.java
@@ -1,10 +1,13 @@
 package com.verifit.verifit.client.oauth2.domain;
 
+import com.verifit.verifit.global.exception.ApiException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
 import java.util.Map;
+
+import static com.verifit.verifit.global.exception.ExceptionCode.OAUTH2_PROVIDER_NOT_SUPPORTED;
 
 
 @RequiredArgsConstructor
@@ -35,7 +38,7 @@ public enum Oauth2UserInfo {
         Oauth2UserInfo oauth2UserInfo = Arrays.stream(Oauth2UserInfo.values())
                 .filter(userInfo -> userInfo.provider.equals(provider))
                 .findAny()
-                .orElseThrow(() -> new IllegalArgumentException("not supported oauth2 provider"));
+                .orElseThrow(() -> new ApiException(OAUTH2_PROVIDER_NOT_SUPPORTED));
         oauth2UserInfo.userAttributes = userAttributes;
         return oauth2UserInfo;
     }

--- a/src/main/java/com/verifit/verifit/global/exception/ApiException.java
+++ b/src/main/java/com/verifit/verifit/global/exception/ApiException.java
@@ -1,0 +1,16 @@
+package com.verifit.verifit.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+    private HttpStatus httpStatus;
+    private String message;
+
+    public ApiException(ExceptionCode e){
+        this.httpStatus = e.getHttpStatus();
+        this.message = e.getMessage();
+    }
+}

--- a/src/main/java/com/verifit/verifit/global/exception/CustomRestControllerAdvice.java
+++ b/src/main/java/com/verifit/verifit/global/exception/CustomRestControllerAdvice.java
@@ -1,0 +1,78 @@
+package com.verifit.verifit.global.exception;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@RestControllerAdvice
+@Slf4j
+public class CustomRestControllerAdvice {
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ExceptionResponse> handleRuntimeException(RuntimeException e, HttpServletRequest request){
+        log.error("RuntimeException : ", e);
+        ExceptionResponse response = ExceptionResponse.of(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                e.getMessage(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e, HttpServletRequest request) {
+        ExceptionResponse response = ExceptionResponse.of(
+                HttpStatus.BAD_REQUEST,
+                e.getBindingResult().getAllErrors().get(0).getDefaultMessage(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(response);
+    }
+
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<ExceptionResponse> handleMissingRequestCookieException(MissingRequestCookieException e, HttpServletRequest request) {
+        ExceptionResponse response = ExceptionResponse.of(
+                HttpStatus.BAD_REQUEST,
+                e.getMessage(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                .body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ExceptionResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e, HttpServletRequest request){
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ExceptionResponse.of(
+                        HttpStatus.BAD_REQUEST,
+                        e.getName() + " argument type miss match",
+                        request.getRequestURI())
+                );
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e, HttpServletRequest request){
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ExceptionResponse.of(
+                        HttpStatus.BAD_REQUEST,
+                        e.getMessage(),
+                        request.getRequestURI())
+                );
+    }
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ExceptionResponse> handleApiException(ApiException e, HttpServletRequest request){
+        ExceptionResponse response = ExceptionResponse.from(e, request.getRequestURI());
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(response);
+    }
+}

--- a/src/main/java/com/verifit/verifit/global/exception/ExceptionCode.java
+++ b/src/main/java/com/verifit/verifit/global/exception/ExceptionCode.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ExceptionCode {
 
+    OAUTH2_PROVIDER_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "oauth2 provider not supported"),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/verifit/verifit/global/exception/ExceptionCode.java
+++ b/src/main/java/com/verifit/verifit/global/exception/ExceptionCode.java
@@ -1,0 +1,15 @@
+package com.verifit.verifit.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ExceptionCode {
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/verifit/verifit/global/exception/ExceptionResponse.java
+++ b/src/main/java/com/verifit/verifit/global/exception/ExceptionResponse.java
@@ -1,0 +1,32 @@
+package com.verifit.verifit.global.exception;
+
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ExceptionResponse(
+        HttpStatus httpStatus,
+        String message,
+        LocalDateTime timestamp,
+        String path
+) {
+    public static ExceptionResponse from(ApiException e, String path) {
+        return ExceptionResponse.builder()
+                .httpStatus(e.getHttpStatus())
+                .message(e.getMessage())
+                .timestamp(LocalDateTime.now())
+                .path(path)
+                .build();
+    }
+
+    public static ExceptionResponse of(HttpStatus httpStatus, String message, String path) {
+        return ExceptionResponse.builder()
+                .httpStatus(httpStatus)
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .path(path)
+                .build();
+    }
+}


### PR DESCRIPTION
일단 제가 사용하던 방식으로 작성해두었습니다.

서비스 로직을 작성하다가 예외가 발생해야 하는 상황이 생기면
ExceptionCode에 적당한 enum값을 추가하고
ApiException을 던저는 식으로 처리하면 됩니다.
Oauth2ProviderFactory나 Oauth2UserInfo 참고하사면 돼요 !

Exception code에 추가적으로 필요한 내용 가령 AUTH001같은 코드가 필요하다거나 하면
같의 논의해보고 추가하면 좋을듯해요