### PR TITLE
Feat/#26 포인트 조회 로직

### DIFF
--- a/src/main/java/com/verifit/verifit/global/config/JpaConfig.java
+++ b/src/main/java/com/verifit/verifit/global/config/JpaConfig.java
@@ -1,0 +1,21 @@
+package com.verifit.verifit.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/verifit/verifit/member/entity/Member.java
+++ b/src/main/java/com/verifit/verifit/member/entity/Member.java
@@ -47,6 +47,12 @@ public class Member {
                 .build();
     }
 
+    public static Member fromId(long id){
+        Member member = new Member();
+        member.id = id;
+        return member;
+    }
+
 
     public void changePassword(String newPassword) {
         password = newPassword;

--- a/src/main/java/com/verifit/verifit/point/dao/CustomPointRepository.java
+++ b/src/main/java/com/verifit/verifit/point/dao/CustomPointRepository.java
@@ -1,0 +1,13 @@
+package com.verifit.verifit.point.dao;
+
+import com.verifit.verifit.point.domain.entity.Point;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface CustomPointRepository {
+
+    public long findMemberMonthlyAccumulatedPoint(long memberId, LocalDateTime dateTime);
+    public Optional<Point> findMemberPointByDateTime(long memberId, LocalDateTime dateTime);
+    public long findMemberAvailablePoint(long memberId, LocalDateTime dateTime);
+}

--- a/src/main/java/com/verifit/verifit/point/dao/CustomPointRepositoryImpl.java
+++ b/src/main/java/com/verifit/verifit/point/dao/CustomPointRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.verifit.verifit.point.dao;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.verifit.verifit.point.domain.entity.Point;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.verifit.verifit.point.domain.entity.QPoint.point;
+
+@RequiredArgsConstructor
+public class CustomPointRepositoryImpl implements CustomPointRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long findMemberMonthlyAccumulatedPoint(long memberId, LocalDateTime dateTime){
+        Long accumulatedPoint = queryFactory.select(point.accumulatedPoint.sum())
+                .from(point)
+                .where(
+                        point.member.id.eq(memberId),
+                        point.startDateTime.year().eq(dateTime.getYear()),
+                        point.startDateTime.month().eq(dateTime.getMonthValue()))
+                .fetchOne();
+
+        return accumulatedPoint == null ? 0 : accumulatedPoint;
+    };
+
+    @Override
+    public Optional<Point> findMemberPointByDateTime(long memberId, LocalDateTime dateTime){
+        Point findPoint = queryFactory.selectFrom(point)
+                .where(
+                        point.member.id.eq(memberId),
+                        point.startDateTime.loe(dateTime),
+                        point.endDateTime.gt(dateTime))
+                .fetchOne();
+        return Optional.ofNullable(findPoint);
+    }
+
+    @Override
+    public long findMemberAvailablePoint(long memberId, LocalDateTime dateTime){
+        Long availablePoint = queryFactory.select(point.availablePoint.sum())
+                .from(point)
+                .where(
+                        point.member.id.eq(memberId),
+                        point.startDateTime.loe(dateTime).and(point.endDateTime.gt(dateTime))
+                                .or(point.startDateTime.loe(dateTime.minusWeeks(1L)).and(point.endDateTime.gt(dateTime.minusWeeks(1L)))))
+                .fetchOne();
+
+        return availablePoint == null ? 0 : availablePoint;
+    }
+}

--- a/src/main/java/com/verifit/verifit/point/dao/PointRepository.java
+++ b/src/main/java/com/verifit/verifit/point/dao/PointRepository.java
@@ -3,5 +3,5 @@ package com.verifit.verifit.point.dao;
 import com.verifit.verifit.point.domain.entity.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PointRepository extends JpaRepository<Point, Long> {
+public interface PointRepository extends JpaRepository<Point, Long>, CustomPointRepository {
 }

--- a/src/main/java/com/verifit/verifit/point/domain/entity/Point.java
+++ b/src/main/java/com/verifit/verifit/point/domain/entity/Point.java
@@ -10,7 +10,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
 
 @Entity
 @Getter
@@ -27,6 +29,19 @@ public class Point {
     private long availablePoint; // 사용 가능한 포인트
     private LocalDateTime startDateTime; // 시즌 시작일
     private LocalDateTime endDateTime; // 시즌 종료일
+
+    public static Point newSeason(long memberId, LocalDateTime now){
+        LocalDateTime startDateTime = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).withHour(0).withMinute(0).withSecond(0);
+        LocalDateTime endDateTime = startDateTime.plusDays(6).withHour(23).withMinute(59).withSecond(59);
+
+        return Point.builder()
+                .member(Member.fromId(memberId))
+                .accumulatedPoint(0)
+                .availablePoint(0)
+                .startDateTime(startDateTime)
+                .endDateTime(endDateTime)
+                .build();
+    }
 
     public void use(long point){
         if (point <= 0) {

--- a/src/main/java/com/verifit/verifit/point/service/PointService.java
+++ b/src/main/java/com/verifit/verifit/point/service/PointService.java
@@ -1,0 +1,31 @@
+package com.verifit.verifit.point.service;
+
+import com.verifit.verifit.point.dao.PointRepository;
+import com.verifit.verifit.point.domain.entity.Point;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PointService {
+
+    private final PointRepository pointRepository;
+
+    public long getMemberMonthlyAccumulatedPoint(long memberId, LocalDateTime now){
+        return pointRepository.findMemberMonthlyAccumulatedPoint(memberId, now);
+    }
+
+    @Transactional
+    public Point getMemberSeasonPoint(long memberId, LocalDateTime now){
+        return pointRepository.findMemberPointByDateTime(memberId, now)
+                .orElseGet(() -> pointRepository.save(Point.newSeason(memberId, now)));
+    }
+
+    public long getMemberAvailablePoint(long memberId, LocalDateTime now){
+        return pointRepository.findMemberAvailablePoint(memberId, now);
+    }
+}

--- a/src/test/java/com/verifit/verifit/point/dao/PointRepositoryTest.java
+++ b/src/test/java/com/verifit/verifit/point/dao/PointRepositoryTest.java
@@ -1,0 +1,110 @@
+package com.verifit.verifit.point.dao;
+
+import com.verifit.verifit.member.dao.MemberRepository;
+import com.verifit.verifit.member.entity.Member;
+import com.verifit.verifit.point.domain.entity.Point;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class PointRepositoryTest {
+
+    @Autowired
+    private PointRepository pointRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    Member member;
+
+    @BeforeEach
+    void setUp(){
+        Member testMember = Member.createMember("김김김김김김김김김", "a@a.a", "password", "https://aaa.aaa");
+        this.member = memberRepository.save(testMember);
+    }
+
+    @DisplayName("회원의 월별 누적 포인트를 조회한다.")
+    @Test
+    void findMemberMonthlyAccumulatedPoint() {
+        // given
+        for (int i = 1; i <= 3; i++) {
+
+            Point point = Point.builder()
+                    .member(member)
+                    .accumulatedPoint(i * 2000)
+                    .availablePoint(i * 1000)
+                    .startDateTime(LocalDateTime.of(2024, 4, i * 7, 0, 0, 0))
+                    .endDateTime(LocalDateTime.of(2024, 4, i * 7 + 6, 0, 0, 0))
+                    .build();
+
+            pointRepository.save(point);
+        }
+
+        LocalDateTime dateTime = LocalDateTime.of(2024, 4, 1, 0, 0, 0);
+
+        // when
+        long accumulatedPoint = pointRepository.findMemberMonthlyAccumulatedPoint(member.getId(), dateTime);
+
+        // then
+        assertThat(accumulatedPoint).isEqualTo(12000);
+    }
+    
+    @DisplayName("회원의 시즌 포인트를 조회한다.")
+    @Test
+    void findMemberPointBySeason() {
+        // given
+        Point point = Point.builder()
+                .member(member)
+                .accumulatedPoint(2000)
+                .availablePoint(1000)
+                .startDateTime(LocalDateTime.of(2024, 4, 7, 0, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 4, 13, 23, 59, 59))
+                .build();
+
+        pointRepository.save(point);
+
+        LocalDateTime dateTime = LocalDateTime.of(2024, 4, 9, 0, 0, 0);
+        
+        // when
+        Point findPoint = pointRepository.findMemberPointByDateTime(member.getId(), dateTime).get();
+
+        // then
+        assertThat(findPoint.getMember().getId()).isEqualTo(member.getId());
+        assertThat(findPoint.getAccumulatedPoint()).isEqualTo(2000);
+        assertThat(findPoint.getAvailablePoint()).isEqualTo(1000);
+        assertThat(dateTime).isBetween(findPoint.getStartDateTime(), findPoint.getEndDateTime());
+    }
+    
+    @DisplayName("회원의 사용 가능한 포인트를 조회한다.")
+    @Test
+    void findMemberAvailablePoint() {
+        // given
+        for (int i = 1; i <= 3; i++) {
+
+            Point point = Point.builder()
+                    .member(member)
+                    .accumulatedPoint(i * 2000)
+                    .availablePoint(i * 1000)
+                    .startDateTime(LocalDateTime.of(2024, 4, i * 7, 0, 0, 0))
+                    .endDateTime(LocalDateTime.of(2024, 4, i * 7 + 6, 0, 0, 0))
+                    .build();
+
+            pointRepository.save(point);
+        }
+
+        LocalDateTime dateTime = LocalDateTime.of(2024, 4, 26, 0, 0, 0);
+        
+        // when
+        long availablePoint = pointRepository.findMemberAvailablePoint(member.getId(), dateTime);
+
+        // then
+        assertThat(availablePoint).isEqualTo(5000);
+    }
+}

--- a/src/test/java/com/verifit/verifit/point/domain/entity/PointTest.java
+++ b/src/test/java/com/verifit/verifit/point/domain/entity/PointTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -62,7 +64,7 @@ class PointTest {
                 .hasMessage(ExceptionCode.REQUEST_POINT_IS_NEGATIVE.getMessage());
     }
     
-    @DisplayName("적립하는 포인튼는 항상 0보다 커야한다.")
+    @DisplayName("적립하는 포인트는 항상 0보다 커야한다.")
     @ParameterizedTest
     @ValueSource(ints = {0, -1000})
     void accumulatePointZeroOrLess(long accumulatePoint) {
@@ -76,5 +78,22 @@ class PointTest {
         assertThatThrownBy(() -> point.accumulate(accumulatePoint))
                 .isInstanceOf(ApiException.class)
                 .hasMessage(ExceptionCode.REQUEST_POINT_IS_NEGATIVE.getMessage());
+    }
+    
+    @DisplayName("새로운 시즌 포인트를 생성한다.")
+    @Test
+    void newSeason() {
+        // given
+        LocalDateTime now = LocalDateTime.of(2024, 4, 4, 10, 10, 10);
+
+        // when
+        Point point = Point.newSeason(1L, now);
+
+        // then
+        assertThat(point.getMember().getId()).isEqualTo(1L);
+        assertThat(point.getAccumulatedPoint()).isEqualTo(0);
+        assertThat(point.getAvailablePoint()).isEqualTo(0);
+        assertThat(point.getStartDateTime()).isEqualTo("2024-04-01T00:00:00");
+        assertThat(point.getEndDateTime()).isEqualTo("2024-04-07T23:59:59");
     }
 }


### PR DESCRIPTION
포인트 조회 로직 추가했습니다

누적 포인트(한달) 기준은 일단 요청한 달을 기준으로 했어요 
시즌 기간은 일주일, 시작은 월요일 00:00:00, 종료는 일요일 23:59:59로 일단 했습니다..
 
query dsl 에서 사용할 JpaQueryFactory도 빈으로 설정해두었습니다.

제가 주로 사용하던 방법이라 혹시 다른 방법이 더 편하시면 바꾸면 될 듯 해요 !