### PR TITLE
feat: add update-user-info endpoint

### DIFF
--- a/src/main/java/com/verifit/verifit/VerifitApplication.java
+++ b/src/main/java/com/verifit/verifit/VerifitApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class) // 스프링 시큐리티 일단 비활성화
+@SpringBootApplication
 public class VerifitApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/verifit/verifit/global/exception/ExceptionCode.java
+++ b/src/main/java/com/verifit/verifit/global/exception/ExceptionCode.java
@@ -18,6 +18,9 @@ public enum ExceptionCode {
 
     // point
     REQUEST_POINT_IS_NEGATIVE(HttpStatus.BAD_REQUEST, "request point is negative"),
+
+    // general
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "server error"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/verifit/verifit/global/exception/ExceptionResponse.java
+++ b/src/main/java/com/verifit/verifit/global/exception/ExceptionResponse.java
@@ -7,14 +7,17 @@ import java.time.LocalDateTime;
 
 @Builder
 public record ExceptionResponse(
-        HttpStatus httpStatus,
+
+        int resultCode,
+//        HttpStatus httpStatus,
         String message,
         LocalDateTime timestamp,
         String path
 ) {
     public static ExceptionResponse from(ApiException e, String path) {
         return ExceptionResponse.builder()
-                .httpStatus(e.getHttpStatus())
+                .resultCode(e.getHttpStatus().value())
+//                .httpStatus(e.getHttpStatus())
                 .message(e.getMessage())
                 .timestamp(LocalDateTime.now())
                 .path(path)
@@ -23,7 +26,8 @@ public record ExceptionResponse(
 
     public static ExceptionResponse of(HttpStatus httpStatus, String message, String path) {
         return ExceptionResponse.builder()
-                .httpStatus(httpStatus)
+                .resultCode(httpStatus.value())
+//                .httpStatus(httpStatus)
                 .message(message)
                 .timestamp(LocalDateTime.now())
                 .path(path)

--- a/src/main/java/com/verifit/verifit/member/entity/Member.java
+++ b/src/main/java/com/verifit/verifit/member/entity/Member.java
@@ -53,6 +53,7 @@ public class Member {
         return member;
     }
 
+    public void changeEmail(String newEmail) { email = newEmail; }
 
     public void changePassword(String newPassword) {
         password = newPassword;

--- a/src/main/java/com/verifit/verifit/member/service/MemberService.java
+++ b/src/main/java/com/verifit/verifit/member/service/MemberService.java
@@ -27,6 +27,16 @@ public class MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("사용자 정보가 존재하지 않습니다."));
     }
 
+
+    @Transactional
+    public void updateEmail(Long memberId, String newEmail) {
+        // 사용자 정보 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보가 존재하지 않습니다."));
+        // 이메일 변경
+        member.changeEmail(newEmail);
+    }
+
     @Transactional
     public void changePassword(Long memberId, String oldPassword, String newPassword) {
         // 사용자 정보 조회
@@ -36,6 +46,17 @@ public class MemberService {
         if (!passwordEncoder.matches(oldPassword, member.getPassword())) {
             throw new IllegalArgumentException("기존 비밀번호가 일치하지 않습니다.");
         }
+        // 새 비밀번호 암호화
+        String encodedNewPassword = passwordEncoder.encode(newPassword);
+        // 비밀번호 변경
+        member.changePassword(encodedNewPassword);
+    }
+
+    @Transactional
+    public  void changePasswordWithoutOldPassword(Long memberId, String newPassword) {
+        // 사용자 정보 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보가 존재하지 않습니다."));
         // 새 비밀번호 암호화
         String encodedNewPassword = passwordEncoder.encode(newPassword);
         // 비밀번호 변경

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,24 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/test_db
+    username: markhan
+    password:
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        #        show_sql: true // 이거보단 logger로 찍자.
+        format_sql: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
+logging.level:
+  org.hibernate.SQL: debug
+  org.hibernate.type: trace
+
+jwt:
+  secret: ${JWT_SECRET_KEY}


### PR DESCRIPTION
# update-user-info
해당 API를 위해 몇가지 작업을 했습니다. 
필요한 로직들을 서비스와 엔티티에 추가했습니다. 


# 에러처리
500번 Server Error를 추가했습니다. 
제네럴한 서버 에러에 사용하면 될 거 같습니다. 

Enum타입 대신 정수형 코드를 반환하게 변경했습니다. 
성공시 응답과 일관성을 위해 변경했습니다. 

## 기타
* 테스트 환경에서만 환경변수 로딩에 문제가 있어서 하드코딩했습니다.
* 스프링 시큐리티 활성화했습니다
  * 편의를 위해 잠시 비활성화 한 채로 앱 실행했었음