### PR TITLE
feat: implement TokenInfo

### DIFF
--- a/src/main/java/com/verifit/verifit/auth/service/AuthService.java
+++ b/src/main/java/com/verifit/verifit/auth/service/AuthService.java
@@ -54,6 +54,12 @@ public class AuthService {
         return jwtProvider.generateAccessToken(member);
     }
 
+    public Member findMemberById(Long memberId) {
+        return memberRepository
+                .findById(memberId)
+                .orElseThrow(() -> new ApiException(ExceptionCode.ACCOUNT_NOT_FOUND));
+    }
+
     private Member findMemberByEmail(String email) {
         return memberRepository
                 .findByEmail(email)

--- a/src/main/java/com/verifit/verifit/global/jwt/TokenInfo.java
+++ b/src/main/java/com/verifit/verifit/global/jwt/TokenInfo.java
@@ -6,49 +6,57 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
+import java.util.Collections;
 
 @Getter
 public class TokenInfo implements UserDetails {
 
     private Long id;
 
+    private String email;
+    private String password;
+    private Collection<? extends GrantedAuthority> authorities;
+
     @Builder
-    public TokenInfo(Long id) {
+    public TokenInfo(Long id, String email, String password, Collection<? extends GrantedAuthority> authorities) {
         this.id = id;
+        this.email = email;
+        this.password = password;
+        this.authorities = authorities;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        return authorities != null ? authorities : Collections.emptyList();
     }
 
     @Override
     public String getPassword() {
-        return null;
+        return password;
     }
 
     @Override
     public String getUsername() {
-        return null;
+        return email;
     }
 
     @Override
     public boolean isAccountNonExpired() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isAccountNonLocked() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isCredentialsNonExpired() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isEnabled() {
-        return false;
+        return true;
     }
 }

--- a/src/main/java/com/verifit/verifit/member/service/MemberService.java
+++ b/src/main/java/com/verifit/verifit/member/service/MemberService.java
@@ -27,6 +27,11 @@ public class MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("사용자 정보가 존재하지 않습니다."));
     }
 
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보가 존재하지 않습니다."));
+    }
+
 
     @Transactional
     public void updateEmail(Long memberId, String newEmail) {

--- a/src/main/java/com/verifit/verifit/mypage/controller/MypageController.java
+++ b/src/main/java/com/verifit/verifit/mypage/controller/MypageController.java
@@ -86,10 +86,13 @@ public class MypageController {
     @PutMapping("/update-user-info")
     public ResponseEntity<Map<String, Object>> updateUserInfo(@AuthenticationPrincipal TokenInfo userDetails,
                                                  @RequestBody Map<String, String> updates) {
+        System.out.println("Received request to update user info");
+        System.out.println("User details: " + userDetails);
+        System.out.println("User email: " + userDetails.getUsername());
+
         if (userDetails == null) {
             throw new ApiException(ExceptionCode.ACCOUNT_NOT_FOUND);
         }
-        System.out.println("User Details: " + userDetails);
 
         Member member = memberService.findMemberByEmail(userDetails.getUsername());
 


### PR DESCRIPTION
# 미구현된 TokenInfo 구현
기존에 값들을 다 null로 리턴하던 TokenInfo 구현했습니다. 
id필드에 더해, email과 password, authorities 정보도 홀딩하도록 변경했습니다. 
JWT 토큰에서 id를 파싱하고, 그걸로 Member를 찾아서 TokenInfo에 설정하게 했습니다. 

## 참고사항
* TokenInfo에 비밀번호를 넣어두는 게 맞는가?
* authorities(유저권한)은 어디에 저장해야 하는가?
  * Member에 필드로 추가해야 되나?
* JwtProvider에서 MemberService 주입하니, 순환 참조 발생. Lazy 어노테이션으로 해결
  * 추후 로직 분리등으로 해결해야 할듯
* 현재 MemberService와 AuthService가 역할이 좀 겹침